### PR TITLE
feat: implement Go Notification service with SQS and DynamoDB integra…

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,6 @@
     <PackageVersion Include="Amazon.Lambda.Core" Version="2.8.1" />
     <PackageVersion Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.5" />
     <PackageVersion Include="Aspire.Elastic.Clients.Elasticsearch" Version="13.1.0" />
-    <PackageVersion Include="Aspire.Hosting.AWS" Version="9.3.2" />
     <PackageVersion Include="Aspire.Hosting.MongoDB" Version="13.1.1" />
     <PackageVersion Include="Aspire.Hosting.NodeJs" Version="9.5.2" />
     <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="13.1.1" />
@@ -22,7 +21,6 @@
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.1.1" />
     <PackageVersion Include="Aspire.Npgsql" Version="13.1.1" />
     <PackageVersion Include="Aspire.Hosting.Elasticsearch" Version="13.1.0" />
-    <PackageVersion Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.3.22" />
     <PackageVersion Include="CommunityToolkit.Aspire.Hosting.Sqlite" Version="13.1.1" />
     <PackageVersion Include="CommunityToolkit.Aspire.Microsoft.EntityFrameworkCore.Sqlite" Version="9.7.2" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4">

--- a/src/AppHost/AppHost.csproj
+++ b/src/AppHost/AppHost.csproj
@@ -10,7 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AWS" />
     <PackageReference Include="Aspire.Hosting.Elasticsearch" />
     <PackageReference Include="Aspire.Hosting.RabbitMQ" />
     <PackageReference Include="Aspire.Hosting.SqlServer" />

--- a/src/Services/Notification/Notification.Go/Dockerfile
+++ b/src/Services/Notification/Notification.Go/Dockerfile
@@ -1,0 +1,28 @@
+# ---- Build stage ----
+FROM golang:1.23-alpine AS builder
+
+WORKDIR /app
+
+COPY go.mod ./
+COPY go.sum* ./
+RUN go mod download 2>/dev/null || true
+
+COPY . .
+RUN go mod tidy && CGO_ENABLED=0 GOOS=linux go build -o /notification .
+
+# ---- Runtime stage ----
+FROM alpine:3.20
+
+RUN apk add --no-cache ca-certificates
+
+COPY --from=builder /notification /notification
+COPY events.json /events.json
+
+ENV APP_MODE=""
+ENV AWS_ENDPOINT_URL=""
+ENV AWS_REGION="us-east-1"
+ENV SQS_QUEUE_URL=""
+ENV SQS_QUEUE_NAME="duckstore-notifications"
+ENV DYNAMODB_TABLE="duckstore-notifications"
+
+ENTRYPOINT ["/notification"]

--- a/src/Services/Notification/Notification.Go/events.json
+++ b/src/Services/Notification/Notification.Go/events.json
@@ -1,0 +1,36 @@
+{
+  "Records": [
+    {
+      "messageId": "test-msg-001",
+      "receiptHandle": "test-receipt-handle-001",
+      "body": "{\"id\":\"notif-20260216T120000\",\"eventType\":\"BasketCheckoutEvent\",\"userName\":\"johndoe\",\"customerId\":\"550e8400-e29b-41d4-a716-446655440000\",\"totalPrice\":259.99,\"firstName\":\"John\",\"lastName\":\"Doe\",\"emailAddress\":\"john.doe@example.com\",\"addressLine\":\"123 Duck Street\",\"country\":\"Brazil\",\"state\":\"SP\",\"zipCode\":\"01001-000\",\"cardName\":\"John Doe\",\"cardNumber\":\"**** **** **** 1234\",\"expiration\":\"12/28\",\"cvv\":\"***\",\"paymentMethod\":1,\"occurredOn\":\"2026-02-16T12:00:00Z\"}",
+      "attributes": {
+        "ApproximateReceiveCount": "1",
+        "SentTimestamp": "1739692800000",
+        "SenderId": "AROAIWPX5BD2BHG722MW4:sender",
+        "ApproximateFirstReceiveTimestamp": "1739692800001"
+      },
+      "messageAttributes": {},
+      "md5OfBody": "d41d8cd98f00b204e9800998ecf8427e",
+      "eventSource": "aws:sqs",
+      "eventSourceARN": "arn:aws:sqs:us-east-1:000000000000:duckstore-notifications",
+      "awsRegion": "us-east-1"
+    },
+    {
+      "messageId": "test-msg-002",
+      "receiptHandle": "test-receipt-handle-002",
+      "body": "{\"id\":\"notif-20260216T120100\",\"eventType\":\"BasketCheckoutEvent\",\"userName\":\"janedoe\",\"customerId\":\"660e8400-e29b-41d4-a716-446655440001\",\"totalPrice\":149.50,\"firstName\":\"Jane\",\"lastName\":\"Doe\",\"emailAddress\":\"jane.doe@example.com\",\"addressLine\":\"456 Quack Avenue\",\"country\":\"Brazil\",\"state\":\"RJ\",\"zipCode\":\"20040-020\",\"cardName\":\"Jane Doe\",\"cardNumber\":\"**** **** **** 5678\",\"expiration\":\"06/27\",\"cvv\":\"***\",\"paymentMethod\":2,\"occurredOn\":\"2026-02-16T12:01:00Z\"}",
+      "attributes": {
+        "ApproximateReceiveCount": "1",
+        "SentTimestamp": "1739692860000",
+        "SenderId": "AROAIWPX5BD2BHG722MW4:sender",
+        "ApproximateFirstReceiveTimestamp": "1739692860001"
+      },
+      "messageAttributes": {},
+      "md5OfBody": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",
+      "eventSource": "aws:sqs",
+      "eventSourceARN": "arn:aws:sqs:us-east-1:000000000000:duckstore-notifications",
+      "awsRegion": "us-east-1"
+    }
+  ]
+}

--- a/src/Services/Notification/Notification.Go/go.mod
+++ b/src/Services/Notification/Notification.Go/go.mod
@@ -1,0 +1,13 @@
+module github.com/duckstore/notification
+
+go 1.23
+
+require (
+	github.com/aws/aws-lambda-go v1.47.0
+	github.com/aws/aws-sdk-go-v2 v1.32.7
+	github.com/aws/aws-sdk-go-v2/config v1.28.7
+	github.com/aws/aws-sdk-go-v2/credentials v1.17.48
+	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.15.22
+	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.38.1
+	github.com/aws/aws-sdk-go-v2/service/sqs v1.37.3
+)

--- a/src/Services/Notification/Notification.Go/main.go
+++ b/src/Services/Notification/Notification.Go/main.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+)
+
+const (
+	defaultQueueName = "duckstore-notifications"
+	defaultTableName = "duckstore-notifications"
+	defaultRegion    = "us-east-1"
+)
+
+func main() {
+	mode := os.Getenv("APP_MODE")
+
+	switch mode {
+	case "lambda":
+		log.Println("[INFO] Starting in Lambda mode")
+		lambda.Start(lambdaHandler)
+
+	default:
+		log.Println("[INFO] Starting in Aspire/standalone SQS poller mode")
+		runPoller()
+	}
+}
+
+// lambdaHandler processes SQS events when running as an AWS Lambda function.
+func lambdaHandler(ctx context.Context, sqsEvent events.SQSEvent) error {
+	log.Printf("[INFO] Lambda invoked with %d record(s)\n", len(sqsEvent.Records))
+
+	cfg, err := newAWSConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to load AWS config: %w", err)
+	}
+
+	store := NewStore(dynamodb.NewFromConfig(cfg), getEnvOrDefault("DYNAMODB_TABLE", defaultTableName))
+
+	for _, record := range sqsEvent.Records {
+		if err := processMessage(ctx, store, record.Body); err != nil {
+			log.Printf("[ERROR] Failed to process record %s: %v\n", record.MessageId, err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+// runPoller continuously polls SQS for messages (standalone / Aspire mode).
+func runPoller() {
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	cfg, err := newAWSConfig(ctx)
+	if err != nil {
+		log.Fatalf("[FATAL] Failed to load AWS config: %v", err)
+	}
+
+	sqsClient := sqs.NewFromConfig(cfg)
+	dynamoClient := dynamodb.NewFromConfig(cfg)
+
+	tableName := getEnvOrDefault("DYNAMODB_TABLE", defaultTableName)
+	store := NewStore(dynamoClient, tableName)
+
+	// Resolve queue URL: prefer SQS_QUEUE_URL (injected by Aspire/CloudFormation),
+	// fall back to looking up by SQS_QUEUE_NAME.
+	queueURL := os.Getenv("SQS_QUEUE_URL")
+	if queueURL == "" {
+		queueName := getEnvOrDefault("SQS_QUEUE_NAME", defaultQueueName)
+
+		// Ensure resources exist (only for local dev with custom endpoints like LocalStack)
+		if os.Getenv("AWS_ENDPOINT_URL") != "" {
+			if err := ensureResources(ctx, sqsClient, dynamoClient, queueName, tableName); err != nil {
+				log.Fatalf("[FATAL] Failed to ensure AWS resources: %v", err)
+			}
+		}
+
+		resolved, err := getQueueURL(ctx, sqsClient, queueName)
+		if err != nil {
+			log.Fatalf("[FATAL] Failed to get queue URL for %q: %v", queueName, err)
+		}
+		queueURL = resolved
+	}
+
+	log.Printf("[INFO] Polling SQS queue: %s\n", queueURL)
+	log.Printf("[INFO] Saving to DynamoDB table: %s\n", tableName)
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Println("[INFO] Shutting down poller...")
+			return
+		default:
+			poll(ctx, sqsClient, store, queueURL)
+		}
+	}
+}
+
+// poll receives messages from SQS and processes them.
+func poll(ctx context.Context, client *sqs.Client, store *Store, queueURL string) {
+	result, err := client.ReceiveMessage(ctx, &sqs.ReceiveMessageInput{
+		QueueUrl:            aws.String(queueURL),
+		MaxNumberOfMessages: 10,
+		WaitTimeSeconds:     20,
+	})
+	if err != nil {
+		log.Printf("[ERROR] Failed to receive messages: %v\n", err)
+		time.Sleep(5 * time.Second)
+		return
+	}
+
+	if len(result.Messages) == 0 {
+		return
+	}
+
+	log.Printf("[INFO] Received %d message(s) from SQS\n", len(result.Messages))
+
+	for _, msg := range result.Messages {
+		body := aws.ToString(msg.Body)
+		msgID := aws.ToString(msg.MessageId)
+
+		log.Printf("[INFO] Processing message ID: %s\n", msgID)
+
+		if err := processMessage(ctx, store, body); err != nil {
+			log.Printf("[ERROR] Failed to process message %s: %v\n", msgID, err)
+			continue
+		}
+
+		// Delete message after successful processing
+		_, err := client.DeleteMessage(ctx, &sqs.DeleteMessageInput{
+			QueueUrl:      aws.String(queueURL),
+			ReceiptHandle: msg.ReceiptHandle,
+		})
+		if err != nil {
+			log.Printf("[ERROR] Failed to delete message %s: %v\n", msgID, err)
+		}
+	}
+}
+
+// processMessage parses and saves a single SQS message body.
+func processMessage(ctx context.Context, store *Store, body string) error {
+	log.Printf("[INFO] Message received: %s\n", body)
+
+	var notification NotificationEvent
+	if err := json.Unmarshal([]byte(body), &notification); err != nil {
+		return fmt.Errorf("failed to unmarshal message: %w", err)
+	}
+
+	// Populate metadata if not set
+	if notification.ID == "" {
+		notification.ID = fmt.Sprintf("notif-%d", time.Now().UnixNano())
+	}
+	if notification.ProcessedAt == "" {
+		notification.ProcessedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+	if notification.Status == "" {
+		notification.Status = "processed"
+	}
+
+	if err := store.Save(ctx, notification); err != nil {
+		log.Printf("[ERROR] Failed to save to DynamoDB: %v\n", err)
+		return err
+	}
+
+	log.Printf("[INFO] Successfully saved notification %s to DynamoDB\n", notification.ID)
+	return nil
+}
+
+// newAWSConfig builds the AWS SDK config, using LocalStack endpoint if set.
+func newAWSConfig(ctx context.Context) (aws.Config, error) {
+	region := getEnvOrDefault("AWS_REGION", defaultRegion)
+
+	opts := []func(*config.LoadOptions) error{
+		config.WithRegion(region),
+	}
+
+	endpoint := os.Getenv("AWS_ENDPOINT_URL")
+	if endpoint != "" {
+		log.Printf("[INFO] Using custom AWS endpoint: %s\n", endpoint)
+		opts = append(opts,
+			config.WithBaseEndpoint(endpoint),
+			config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "test")),
+		)
+	}
+
+	return config.LoadDefaultConfig(ctx, opts...)
+}
+
+func getQueueURL(ctx context.Context, client *sqs.Client, queueName string) (string, error) {
+	result, err := client.GetQueueUrl(ctx, &sqs.GetQueueUrlInput{
+		QueueName: aws.String(queueName),
+	})
+	if err != nil {
+		return "", err
+	}
+	return aws.ToString(result.QueueUrl), nil
+}
+
+func getEnvOrDefault(key, defaultValue string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return defaultValue
+}

--- a/src/Services/Notification/Notification.Go/main_test.go
+++ b/src/Services/Notification/Notification.Go/main_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNotificationEventUnmarshal(t *testing.T) {
+	body := `{
+		"id": "notif-001",
+		"eventType": "BasketCheckoutEvent",
+		"userName": "johndoe",
+		"customerId": "550e8400-e29b-41d4-a716-446655440000",
+		"totalPrice": 259.99,
+		"firstName": "John",
+		"lastName": "Doe",
+		"emailAddress": "john.doe@example.com",
+		"addressLine": "123 Duck Street",
+		"country": "Brazil",
+		"state": "SP",
+		"zipCode": "01001-000",
+		"cardName": "John Doe",
+		"cardNumber": "**** **** **** 1234",
+		"expiration": "12/28",
+		"cvv": "***",
+		"paymentMethod": 1,
+		"occurredOn": "2026-02-16T12:00:00Z"
+	}`
+
+	var event NotificationEvent
+	err := json.Unmarshal([]byte(body), &event)
+	if err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if event.ID != "notif-001" {
+		t.Errorf("expected ID 'notif-001', got %q", event.ID)
+	}
+	if event.EventType != "BasketCheckoutEvent" {
+		t.Errorf("expected EventType 'BasketCheckoutEvent', got %q", event.EventType)
+	}
+	if event.UserName != "johndoe" {
+		t.Errorf("expected UserName 'johndoe', got %q", event.UserName)
+	}
+	if event.TotalPrice != 259.99 {
+		t.Errorf("expected TotalPrice 259.99, got %f", event.TotalPrice)
+	}
+	if event.PaymentMethod != 1 {
+		t.Errorf("expected PaymentMethod 1, got %d", event.PaymentMethod)
+	}
+	if event.EmailAddress != "john.doe@example.com" {
+		t.Errorf("expected EmailAddress 'john.doe@example.com', got %q", event.EmailAddress)
+	}
+}
+
+func TestNotificationEventDefaultValues(t *testing.T) {
+	body := `{"eventType": "BasketCheckoutEvent", "userName": "test"}`
+
+	var event NotificationEvent
+	err := json.Unmarshal([]byte(body), &event)
+	if err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	// ID should be empty (processMessage fills it in)
+	if event.ID != "" {
+		t.Errorf("expected empty ID, got %q", event.ID)
+	}
+	if event.EventType != "BasketCheckoutEvent" {
+		t.Errorf("expected EventType 'BasketCheckoutEvent', got %q", event.EventType)
+	}
+}
+
+func TestGetEnvOrDefault(t *testing.T) {
+	result := getEnvOrDefault("NONEXISTENT_ENV_VAR_FOR_TEST", "fallback")
+	if result != "fallback" {
+		t.Errorf("expected 'fallback', got %q", result)
+	}
+
+	t.Setenv("TEST_ENV_VAR_SET", "myvalue")
+	result = getEnvOrDefault("TEST_ENV_VAR_SET", "fallback")
+	if result != "myvalue" {
+		t.Errorf("expected 'myvalue', got %q", result)
+	}
+}
+
+func TestNewNotificationID(t *testing.T) {
+	id := NewNotificationID()
+	if len(id) == 0 {
+		t.Error("expected non-empty NotificationID")
+	}
+	if id[:6] != "notif-" {
+		t.Errorf("expected ID to start with 'notif-', got %q", id)
+	}
+}

--- a/src/Services/Notification/Notification.Go/model.go
+++ b/src/Services/Notification/Notification.Go/model.go
@@ -1,0 +1,32 @@
+package main
+
+import "time"
+
+// NotificationEvent represents a checkout notification to be stored in DynamoDB.
+type NotificationEvent struct {
+	ID            string  `json:"id" dynamodbav:"PK"`
+	EventType     string  `json:"eventType" dynamodbav:"EventType"`
+	UserName      string  `json:"userName" dynamodbav:"UserName"`
+	CustomerID    string  `json:"customerId" dynamodbav:"CustomerId"`
+	TotalPrice    float64 `json:"totalPrice" dynamodbav:"TotalPrice"`
+	FirstName     string  `json:"firstName" dynamodbav:"FirstName"`
+	LastName      string  `json:"lastName" dynamodbav:"LastName"`
+	EmailAddress  string  `json:"emailAddress" dynamodbav:"EmailAddress"`
+	AddressLine   string  `json:"addressLine" dynamodbav:"AddressLine"`
+	Country       string  `json:"country" dynamodbav:"Country"`
+	State         string  `json:"state" dynamodbav:"State"`
+	ZipCode       string  `json:"zipCode" dynamodbav:"ZipCode"`
+	CardName      string  `json:"cardName" dynamodbav:"CardName"`
+	CardNumber    string  `json:"cardNumber" dynamodbav:"CardNumber"`
+	Expiration    string  `json:"expiration" dynamodbav:"Expiration"`
+	CVV           string  `json:"cvv" dynamodbav:"CVV"`
+	PaymentMethod int     `json:"paymentMethod" dynamodbav:"PaymentMethod"`
+	Status        string  `json:"status" dynamodbav:"Status"`
+	ProcessedAt   string  `json:"processedAt" dynamodbav:"ProcessedAt"`
+	OccurredOn    string  `json:"occurredOn" dynamodbav:"OccurredOn"`
+}
+
+// NewNotificationID generates a unique notification ID based on the current timestamp.
+func NewNotificationID() string {
+	return "notif-" + time.Now().UTC().Format("20060102T150405.000000000")
+}

--- a/src/Services/Notification/Notification.Go/resources.go
+++ b/src/Services/Notification/Notification.Go/resources.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	dbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+)
+
+// ensureResources creates the SQS queue and DynamoDB table if they don't exist.
+// This is used in local development with LocalStack.
+func ensureResources(ctx context.Context, sqsClient *sqs.Client, dynamoClient *dynamodb.Client, queueName, tableName string) error {
+	if err := ensureQueue(ctx, sqsClient, queueName); err != nil {
+		return err
+	}
+	return ensureTable(ctx, dynamoClient, tableName)
+}
+
+func ensureQueue(ctx context.Context, client *sqs.Client, queueName string) error {
+	_, err := client.GetQueueUrl(ctx, &sqs.GetQueueUrlInput{
+		QueueName: aws.String(queueName),
+	})
+	if err == nil {
+		log.Printf("[INFO] SQS queue %q already exists\n", queueName)
+		return nil
+	}
+
+	log.Printf("[INFO] Creating SQS queue %q...\n", queueName)
+	_, err = client.CreateQueue(ctx, &sqs.CreateQueueInput{
+		QueueName: aws.String(queueName),
+	})
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] SQS queue %q created successfully\n", queueName)
+	return nil
+}
+
+func ensureTable(ctx context.Context, client *dynamodb.Client, tableName string) error {
+	_, err := client.DescribeTable(ctx, &dynamodb.DescribeTableInput{
+		TableName: aws.String(tableName),
+	})
+	if err == nil {
+		log.Printf("[INFO] DynamoDB table %q already exists\n", tableName)
+		return nil
+	}
+
+	log.Printf("[INFO] Creating DynamoDB table %q...\n", tableName)
+	_, err = client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName: aws.String(tableName),
+		KeySchema: []dbtypes.KeySchemaElement{
+			{
+				AttributeName: aws.String("PK"),
+				KeyType:       dbtypes.KeyTypeHash,
+			},
+		},
+		AttributeDefinitions: []dbtypes.AttributeDefinition{
+			{
+				AttributeName: aws.String("PK"),
+				AttributeType: dbtypes.ScalarAttributeTypeS,
+			},
+		},
+		BillingMode: dbtypes.BillingModePayPerRequest,
+	})
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] DynamoDB table %q created successfully\n", tableName)
+	return nil
+}

--- a/src/Services/Notification/Notification.Go/store.go
+++ b/src/Services/Notification/Notification.Go/store.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+)
+
+// Store handles DynamoDB persistence for notification events.
+type Store struct {
+	client    *dynamodb.Client
+	tableName string
+}
+
+// NewStore creates a new DynamoDB store.
+func NewStore(client *dynamodb.Client, tableName string) *Store {
+	return &Store{
+		client:    client,
+		tableName: tableName,
+	}
+}
+
+// Save persists a NotificationEvent to DynamoDB.
+func (s *Store) Save(ctx context.Context, event NotificationEvent) error {
+	item, err := attributevalue.MarshalMap(event)
+	if err != nil {
+		return fmt.Errorf("failed to marshal notification event: %w", err)
+	}
+
+	_, err = s.client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: &s.tableName,
+		Item:      item,
+	})
+	if err != nil {
+		log.Printf("[ERROR] DynamoDB PutItem failed for ID=%s: %v\n", event.ID, err)
+		return fmt.Errorf("failed to put item in DynamoDB: %w", err)
+	}
+
+	log.Printf("[INFO] DynamoDB PutItem succeeded for ID=%s, Table=%s\n", event.ID, s.tableName)
+	return nil
+}


### PR DESCRIPTION
This pull request introduces a new Go-based notification service that consumes SQS messages and persists notification events to DynamoDB, supporting both AWS Lambda and local development with LocalStack. The changes include the full implementation of the Go service, infrastructure for local AWS emulation, and removal of now-unneeded AWS hosting dependencies from the .NET solution.

**Key changes:**

**1. New Go Notification Service Implementation**
- Added a new Go service (`Notification.Go`) for processing SQS messages and storing them in DynamoDB, with support for both AWS Lambda and local Aspire/standalone polling modes (`main.go`, `model.go`, `store.go`, `resources.go`). [[1]](diffhunk://#diff-894922ca28fc0e843082b5c58597d53e5139a665680c0d51403c9953e928e2f0R1-R218) [[2]](diffhunk://#diff-5bdcefc2221f39bf78061179f0f07894669df377eccf3c6b09fc225b79c4f432R1-R32) [[3]](diffhunk://#diff-d4c24bd874de21526febe26e7fe009c8d37dc847677a42011fe1f0ef06d8cd4dR1-R44) [[4]](diffhunk://#diff-c7bee2631bafc6b65a2c1603bed9bbbc6a572e6e2d4b664684715afb12a66004R1-R75)
- Introduced unit tests for event parsing, environment variable handling, and notification ID generation (`main_test.go`).
- Defined Go module dependencies for AWS SDK and Lambda support (`go.mod`).

**2. Local Development Support & Integration**
- Added a Dockerfile for building and running the Go notification service, with environment variables for AWS endpoints and resource names (`Dockerfile`).
- Included a sample `events.json` for local testing of SQS event payloads (`events.json`).
- Updated the .NET host (`Program.cs`) to launch LocalStack for local SQS/DynamoDB emulation and to start the Go notification service with appropriate environment configuration.

**3. Dependency Cleanup**
- Removed `Aspire.Hosting.AWS` and `AWSSDK.Extensions.NETCore.Setup` package references from solution-wide and project-specific configuration files, as AWS resource hosting is now handled by LocalStack and the Go service. [[1]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L12) [[2]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L25) [[3]](diffhunk://#diff-b567b7f5c14c731999a08ea97ea0b852616628d6f0bff81e1bc3761f1b05564cL13)…tion